### PR TITLE
Handle accessing properties of empty arrays

### DIFF
--- a/lib/evaluator/handlers.js
+++ b/lib/evaluator/handlers.js
@@ -83,8 +83,8 @@ exports.FilterExpression = function(ast) {
 exports.Identifier = function(ast) {
   if (ast.from) {
     return this.eval(ast.from).then(function(context) {
-      if (context === undefined) return undefined;
       if (Array.isArray(context)) context = context[0];
+      if (context === undefined) return undefined;
       return context[ast.value];
     });
   } else {

--- a/test/evaluator/Evaluator.js
+++ b/test/evaluator/Evaluator.js
@@ -147,6 +147,11 @@ describe("Evaluator", function() {
       .eval(toTree('["foo", 1+2]'))
       .should.eventually.deep.equal(["foo", 3]);
   });
+  it("should allow properties on empty arrays", function() {
+    var context = { foo: {} },
+      e = new Evaluator(grammar, null, context);
+    return e.eval(toTree("[].baz")).should.become(undefined);
+  });
   it('should apply the "in" operator to strings', function() {
     var e = new Evaluator(grammar);
     return Promise.all([


### PR DESCRIPTION
In https://bugzilla.mozilla.org/show_bug.cgi?id=1477156 we discovered that under certain circumstances we could produce an undefined-dereferencing error. Specifically, the circumstances were:

1. take a defined object
2. do some kind of invalid filtering on it (`[.foo]`)
3. and then get a property of that

It turns out that steps 1 and 2 are valid, and they produce an empty array. The problem is in step 3, which fails on an empty array. This PR fixes the problem, first by introducing a failing test using an empty array (e.g. `[].anything`), and then fixing the problem.