### PR TITLE
Short-circuit logical operators

### DIFF
--- a/lib/evaluator/handlers.js
+++ b/lib/evaluator/handlers.js
@@ -26,6 +26,22 @@ exports.ArrayLiteral = function(ast) {
  */
 exports.BinaryExpression = function(ast) {
   var self = this;
+  if (ast.operator === "&&") {
+    return this.eval(ast.left).then(function(left) {
+      if (!left) return left;
+      return self.eval(ast.right).then(function(right) {
+        return self._grammar[ast.operator].eval(left, right);
+      });
+    });
+  }
+  if (ast.operator === "||") {
+    return this.eval(ast.left).then(function(left) {
+      if (left) return left;
+      return self.eval(ast.right).then(function(right) {
+        return self._grammar[ast.operator].eval(left, right);
+      });
+    });
+  }
   return Promise.all([this.eval(ast.left), this.eval(ast.right)]).then(function(
     arr
   ) {

--- a/test/Jexl.js
+++ b/test/Jexl.js
@@ -64,6 +64,20 @@ describe("Jexl", function() {
   it("should pass context", function() {
     return inst.eval("foo", { foo: "bar" }).should.become("bar");
   });
+  it("should short-circuit logical AND", function() {
+    return inst
+      .eval("browserSettings && browserSettings.something", {
+        browserSettings: null
+      })
+      .should.become(null);
+  });
+  it("should short-circuit logical OR", function() {
+    return inst
+      .eval("true || browserSettings.foo", {
+        browserSettings: null
+      })
+      .should.become(true);
+  });
   it("should allow binaryOps to be defined", function() {
     inst.addBinaryOp("_=", 20, function(left, right) {
       return left.toLowerCase() === right.toLowerCase();


### PR DESCRIPTION
Fixes #34.

## What changed

- Evaluate `&&` and `||` lazily in `BinaryExpression` instead of resolving both sides up front.
- Preserve the existing operator behavior when the right side does need to run.
- Add regression coverage for null object access behind short-circuited logical expressions.

## Why

`BinaryExpression` previously used `Promise.all([left, right])` for every binary operator. That meant `true || browserSettings.foo` and `browserSettings && browserSettings.something` still evaluated the right-hand side, so null contexts could throw before the logical operator had a chance to short-circuit.

## Validation

- `npm run lint`
- `npm test`
- `git diff --check`